### PR TITLE
Improve README path example

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,31 @@ To use the system, **you must update the following placeholders with your own lo
      "add path here"    // Path to your 'websites' folder
    ]
    ```
+Example paths:
+
+   ```json
+   "args": [
+     "-y",
+     "@modelcontextprotocol/server-filesystem",
+     "C:/ResearchData/parsed",
+     "C:/ResearchData/websites"
+   ]
+   ```
+   This assumes you have a `ResearchData` directory with `parsed` and `websites` subfolders.
+
 
 2. **`research_server.py`**
 
    ```python
    PAPER_TXT_DIR = Path("add path here")  # Set this to your parsed papers directory
    ```
+   Example:
+
+   ```python
+   PAPER_TXT_DIR = Path("C:/ResearchData/parsed")
+   ```
+   Make sure this matches the `parsed` folder path in your `server_config.json`.
+
 
 3. **Inside Prompts**
    Look for any text that includes `'add path here'` and update it with your preferred local directory path.


### PR DESCRIPTION
## Summary
- clarify local path examples in the **Path updates** section

## Testing
- `uv pip install -e .` *(fails: No virtual environment)*

------
https://chatgpt.com/codex/tasks/task_e_684ecf9e0038832ab1a8e863d2ebda8d